### PR TITLE
ReactDom経緯のエラー解消

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 import React from "react";
-import ReactDOM  from "react-dom";
-
 import App from './App';
+import {createRoot} from 'react-dom/client';
 
-ReactDOM.render(<App />, document.querySelector('#root'));
-
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
# ReactDomでレンダリングした際に生じるエラーを解消
- createRootをreact-dom/clientからimportして使用